### PR TITLE
feat: add Ubuntu 26.04 LTS (Resolute Raccoon) support

### DIFF
--- a/internal/apt/apt.go
+++ b/internal/apt/apt.go
@@ -230,8 +230,9 @@ func UpdatePackageLists(ctx context.Context, verbose bool) func() error {
 // AddAptRepositories configures the system's apt repositories based on the Ubuntu release codename.
 // It first retrieves the current Ubuntu codename using "lsb_release -sc".
 // Then it resets the repository configuration by removing and recreating the "/etc/apt/sources.list.d/" directory.
-// Depending on the codename (e.g., matching "jammy" or "noble"), it adds a predefined list of repository entries
-// to the main sources file ("/etc/apt/sources.list") using the helper function addRepo.
+// Depending on the codename (e.g., matching "jammy", "noble", or "resolute"), it adds a predefined list of
+// repository entries to the main sources file ("/etc/apt/sources.list") using the helper function addRepo.
+// Releases using the DEB822 .sources format (noble, resolute, and later) are handled with a shared branch.
 // If the release codename is unsupported or any step fails, an error is returned.
 // The context parameter is used for external command execution but not for local file I/O
 // operations, as Go's standard library does not provide context-aware file operations.
@@ -256,8 +257,9 @@ func AddAptRepositories(ctx context.Context, verbose bool) error {
 	sourcesFile := "/etc/apt/sources.list"
 
 	// Define regex patterns to identify specific Ubuntu releases.
-	jammyRegex := regexp.MustCompile(`(jammy)$`)
-	nobleRegex := regexp.MustCompile(`(noble)$`)
+	jammyRegex  := regexp.MustCompile(`(jammy)$`)
+	// deb822Regex matches all releases that use the DEB822 .sources format (noble, resolute, and later).
+	deb822Regex := regexp.MustCompile(`(noble|resolute)$`)
 
 	// Remove repository configuration files, but preserve ubuntu.sources on Noble
 	sourcesDir := "/etc/apt/sources.list.d/"
@@ -272,10 +274,10 @@ func AddAptRepositories(ctx context.Context, verbose bool) error {
 	removedCount := 0
 	for _, entry := range entries {
 		filePath := filepath.Join(sourcesDir, entry.Name())
-		// On Noble, skip deleting ubuntu.sources
-		if nobleRegex.MatchString(release) && entry.Name() == "ubuntu.sources" {
+		// On DEB822-format releases (noble, resolute, …), preserve ubuntu.sources.
+		if deb822Regex.MatchString(release) && entry.Name() == "ubuntu.sources" {
 			if verbose {
-				fmt.Printf("  Preserving %s (required for Noble)\n", entry.Name())
+				fmt.Printf("  Preserving %s (required for DEB822-format release)\n", entry.Name())
 			}
 			continue
 		}
@@ -313,11 +315,11 @@ func AddAptRepositories(ctx context.Context, verbose bool) error {
 		if verbose {
 			fmt.Printf("Successfully configured %d repositories in %s\n", len(repos), sourcesFile)
 		}
-	} else if nobleRegex.MatchString(release) {
+	} else if deb822Regex.MatchString(release) {
 		if verbose {
-			fmt.Printf("Configuring repositories for Ubuntu %s (using DEB822 format)\n", release)
+			fmt.Printf("Configuring repositories for Ubuntu %s (DEB822 format)\n", release)
 		}
-		// On Noble, check if the existing ubuntu.sources uses the official archive
+		// On DEB822-format releases, check if ubuntu.sources uses the official archive.
 		ubuntuSourcesFile := filepath.Join(sourcesDir, "ubuntu.sources")
 		if verbose {
 			fmt.Printf("Checking existing mirror configuration in %s\n", ubuntuSourcesFile)
@@ -351,7 +353,7 @@ func AddAptRepositories(ctx context.Context, verbose bool) error {
 			archiveSourcesFile := filepath.Join(sourcesDir, "ubuntu-archive.sources")
 
 			// Create DEB822 format content for official Ubuntu archives
-			deb822Content := buildNobleSourcesContent(release)
+			deb822Content := buildDEB822SourcesContent(release)
 
 			if verbose {
 				fmt.Println("\nWriting ubuntu-archive.sources with content:")
@@ -380,9 +382,10 @@ func AddAptRepositories(ctx context.Context, verbose bool) error {
 	return nil
 }
 
-// buildNobleSourcesContent generates DEB822 format content for Noble Ubuntu archives.
-// It returns a properly formatted .sources file content string.
-func buildNobleSourcesContent(release string) string {
+// buildDEB822SourcesContent generates DEB822 format content for Ubuntu releases that use
+// the .sources file format (noble, resolute, and later). It returns a properly formatted
+// .sources file content string that works for any such release.
+func buildDEB822SourcesContent(release string) string {
 	return fmt.Sprintf(
 		"Types: deb\n"+
 			"URIs: http://archive.ubuntu.com/ubuntu/\n"+

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -26,7 +26,7 @@ const (
 	AnsibleRequirementsPath           = "/srv/git/saltbox/requirements/requirements-saltbox.txt"
 	AnsibleVenvPythonVersion          = "3.12"
 	PythonInstallDir                  = "/srv/python"
-	SupportedUbuntuReleases           = "22.04,24.04"
+	SupportedUbuntuReleases           = "22.04,24.04,26.04"
 	DockerControllerServiceFile       = "/etc/systemd/system/saltbox_managed_docker_controller.service"
 	DockerControllerAPIURL            = "http://127.0.0.1:3377"
 	SVMVersionProxyURL                = "https://svm.saltbox.dev/version"

--- a/main.go
+++ b/main.go
@@ -65,7 +65,7 @@ func main() {
 		os.Exit(exitCode)
 	}
 
-	supportedVersions := []string{"20.04", "22.04", "24.04"}
+	supportedVersions := []string{"20.04", "22.04", "24.04", "26.04"}
 
 	if err := ubuntu.CheckSupport(supportedVersions); err != nil {
 		fmt.Println(err)

--- a/main_test.go
+++ b/main_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestMainPackageStructure(t *testing.T) {
 	t.Run("verify supported versions", func(t *testing.T) {
-		supportedVersions := []string{"20.04", "22.04", "24.04"}
+		supportedVersions := []string{"20.04", "22.04", "24.04", "26.04"}
 
 		if len(supportedVersions) == 0 {
 			t.Error("Supported versions should not be empty")
@@ -229,11 +229,11 @@ func TestUbuntuVersionValidation(t *testing.T) {
 		{
 			name:    "Ubuntu 26.04",
 			version: "26.04",
-			valid:   false,
+			valid:   true,
 		},
 	}
 
-	supportedVersions := []string{"20.04", "22.04", "24.04"}
+	supportedVersions := []string{"20.04", "22.04", "24.04", "26.04"}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -337,7 +337,7 @@ func TestMainFlowStructure(t *testing.T) {
 			_ = args // Would be used in relaunch
 		} else {
 			// Root - would proceed with normal execution
-			supportedVersions := []string{"20.04", "22.04", "24.04"}
+			supportedVersions := []string{"20.04", "22.04", "24.04", "26.04"}
 			if len(supportedVersions) == 0 {
 				t.Error("Supported versions should be defined")
 			}


### PR DESCRIPTION
- main.go: add "26.04" to supported versions allowlist
- internal/constants/constants.go: add 26.04 to SupportedUbuntuReleases string
- internal/apt/apt.go: extend APT repo handling to cover resolute using the existing DEB822 branch (noble and resolute share the same sources format); rename nobleRegex → deb822Regex and buildNobleSourcesContent → buildDEB822SourcesContent
- main_test.go: update test fixtures to include 26.04 as a valid version

All changes are additive; existing jammy and noble behavior is unchanged.